### PR TITLE
Username encoding

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 /.project
 /.settings
 /bin/
+.idea
+*.iml

--- a/src/java/fr/paris/lutece/plugins/participatoryideation/modules/participatorybudget/service/myinfos/MyInfosFromParticipatoryBudgetService.java
+++ b/src/java/fr/paris/lutece/plugins/participatoryideation/modules/participatorybudget/service/myinfos/MyInfosFromParticipatoryBudgetService.java
@@ -38,6 +38,9 @@ import org.json.JSONObject;
 import fr.paris.lutece.plugins.participatoryideation.service.myinfos.IMyInfosService;
 import fr.paris.lutece.plugins.participatoryideation.service.rest.AbstractRestBasedService;
 import fr.paris.lutece.portal.service.util.AppPropertiesService;
+import java.io.UnsupportedEncodingException;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 
 /**
  * This class provides 'myinfos' services from plugin-participatorybudget. It uses the REST API of the plugin.
@@ -56,7 +59,7 @@ public class MyInfosFromParticipatoryBudgetService extends AbstractRestBasedServ
     @Override
     public boolean isUserValid( String userId )
     {
-        JSONObject json = doGetJSon( REST_URL + userId + "/are-myinfos-valid" );
+        JSONObject json = doGetJSon( REST_URL + encodeValue( userId ) + "/are-myinfos-valid" );
         return parseBoolean( json );
     }
 
@@ -72,4 +75,19 @@ public class MyInfosFromParticipatoryBudgetService extends AbstractRestBasedServ
         return parseString( json );
     }
 
+    /**
+     * Return the url-encoded string, handling special characters
+     *
+     * @param value
+     *           Raw url parameter
+     *
+     * @return String The url-encoded string
+     */
+    private static String encodeValue(String value) {
+        try {
+            return URLEncoder.encode(value, StandardCharsets.UTF_8.toString());
+        } catch (UnsupportedEncodingException ex) {
+            throw new RuntimeException(ex.getCause());
+        }
+    }
 }


### PR DESCRIPTION
Unfortunately, you can register with special characters when creating a user.

This changes solves the character encoding problem.

```06/10/20 13:26:35 DEBUG [http-nio-8080-exec-10] lutece.rest - LuteceJerseySpringServlet processing request : GET /pb/rest/campaign/A/IDEATION/during
06/10/20 13:26:35 ERROR [http-nio-8080-exec-4] lutece.error - An error occurs when calling 'http://localhost:8080/pb/rest/myinfos/kĂˇtya/are-myinfos-valid'
java.lang.IllegalArgumentException: Invalid uri 'http://localhost:8080/pb/rest/myinfos/kĂˇtya/are-myinfos-valid': escaped absolute path not valid```